### PR TITLE
Tracking link changed to aftership

### DIFF
--- a/postify/database_managing/models.py
+++ b/postify/database_managing/models.py
@@ -41,7 +41,7 @@ class Scheduled_Order(Base):
             elif entry_time.hour >= 12 and hour_difference >= 27:
                 pass
             
-            print(f"from : {entry_time} to : current time : {current_time} = {hour_difference}")
+            #print(f"from : {entry_time} to : current time : {current_time} = {hour_difference}")
         except Exception as e:
             print(e)
         else:

--- a/postify/main.py
+++ b/postify/main.py
@@ -18,6 +18,7 @@ from pprint import pprint
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 import requests
+import pytz
 
 
 app = FastAPI()
@@ -25,7 +26,6 @@ app.add_middleware(
     CORSMiddleware,allow_origins = ALLOWED_ORIGINS,allow_credentials = True,
     allow_methods = ["GET"],allow_headers = ["*"],
 )
-
 
 app.mount("/postify/static", StaticFiles(directory="postify/static"), name="postify_static")
 templates = Jinja2Templates(directory="postify/templates")
@@ -43,24 +43,24 @@ def get_order(identification : str):
             order_response["Name"] = scheduled_order.Name
             order_response["Order_id"] = scheduled_order.Order_ID
             order_response["Mobile"] = scheduled_order.Mobile
+            
             order_response.update({
                 "Speedpost Tracking Id" : scheduled_order.Barcode,
+            })
+            order_response.update({
                 "Scheduled on " : scheduled_order.Entry_Date
             })
-            
             # Order Status
             order_response["Status"] = f"Scheduled"
             if scheduled_order.is_bagged() == True:
                 aftership = f"https://www.aftership.com/track/india-post/{scheduled_order.Barcode}"
                 indiapost = "https://www.indiapost.gov.in"
                 
-                aftership_response = requests.get(aftership)
-                print(aftership_response.status_code)
-                
                 order_response['Status'] += f", Track from : {aftership}"
                 
             elif scheduled_order.is_bagged() == False:
-                order_response["Status"] += ", Tracking link will be available soon."
+                order_response["Status"] += ", Tracking link will be available afternoon."
+                
         else:
             unscheduled_order = sh_inst.search_in_all_stores()
             status = 200

--- a/postify/main.py
+++ b/postify/main.py
@@ -17,6 +17,8 @@ import re, uvicorn
 from pprint import pprint
 from jinja2 import Environment, PackageLoader, select_autoescape
 
+import requests
+
 
 app = FastAPI()
 app.add_middleware(
@@ -49,7 +51,14 @@ def get_order(identification : str):
             # Order Status
             order_response["Status"] = f"Scheduled"
             if scheduled_order.is_bagged() == True:
-                order_response['Status'] += f", Tracking link : https://www.aftership.com/track/india-post/{scheduled_order.Barcode}"
+                aftership = f"https://www.aftership.com/track/india-post/{scheduled_order.Barcode}"
+                indiapost = "https://www.indiapost.gov.in"
+                
+                aftership_response = requests.get(aftership)
+                print(aftership_response.status_code)
+                
+                order_response['Status'] += f", Track from : {aftership}"
+                
             elif scheduled_order.is_bagged() == False:
                 order_response["Status"] += ", Tracking link will be available soon."
         else:
@@ -89,7 +98,6 @@ def order_page(request : Request, identification : str):
                 
                 if link_matches:
                     matched_link = link_matches.group()
-                    print(matched_link)
                     value = value.replace(
                         matched_link, 
                         f"<a target='_blank' href='{matched_link}'>{matched_link.strip("https://www.")}</a>"

--- a/postify/main.py
+++ b/postify/main.py
@@ -79,22 +79,22 @@ def order_page(request : Request, identification : str):
         if order:
             status = 200
             
-            tracking_id_pattern = r'EL\d{9}IN'
-            link_pattern = r'https://[^\s"\'<>]+'
+            tracking_id_pattern = r'^EL\d{9}IN'
+            link_pattern = r'https://.*'
             
             for key,value in order.items():
-                link_matches = re.search(link_pattern,value)
-                tracking_id_matches = re.search(tracking_id_pattern,value)
-                print(link_matches)
                 
-                """
+                link_matches = re.search(link_pattern,value)
+                tracking_id_matches = re.match(tracking_id_pattern,value)
+                
                 if link_matches:
                     matched_link = link_matches.group()
+                    print(matched_link)
                     value = value.replace(
                         matched_link, 
                         f"<a target='_blank' href='{matched_link}'>{matched_link.strip("https://www.")}</a>"
                     )
-                """
+                
                 if tracking_id_matches:
                     matched_tracking_id = tracking_id_matches.group()
                     tag = 'span'


### PR DESCRIPTION
## Summary by Sourcery

Generate Aftership tracking URLs for orders once they are considered bagged and update the templating logic to detect and render tracking links and IDs consistently.

New Features:
- Introduce is_bagged method on Scheduled_Order to determine if an order is bagged based on its entry time in the Asia/Kolkata timezone
- Display Aftership tracking links in the order status once orders are bagged, with a fallback message for unbagged orders

Enhancements:
- Refine regex patterns for URL and tracking ID detection in order_page and convert matches into clickable links or copyable spans

Chores:
- Add requests and pytz imports for new time and HTTP handling