### PR TITLE
fixed bug on afternoon schedules

### DIFF
--- a/postify/database_managing/models.py
+++ b/postify/database_managing/models.py
@@ -39,7 +39,7 @@ class Scheduled_Order(Base):
             if entry_time.hour < 12 and hour_difference >= 7:
                 bagged = True
             elif entry_time.hour >= 12 and hour_difference >= 27:
-                pass
+                bagged = True
             
             #print(f"from : {entry_time} to : current time : {current_time} = {hour_difference}")
         except Exception as e:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Assign bagged=True for entry_time.hour >= 12 when hour_difference >= 27 instead of skipping it