### PR TITLE
fixed none type error for shopify basic store

### DIFF
--- a/postify/main.py
+++ b/postify/main.py
@@ -17,7 +17,6 @@ import re, uvicorn
 from pprint import pprint
 from jinja2 import Environment, PackageLoader, select_autoescape
 
-import requests, pytz
 
 import pandas as pd
 from io import StringIO
@@ -74,7 +73,7 @@ class Order:
     def order_page(self, request : Request, identification : str):
         track = Tracking()
         try:
-            return track.track(request=request,identification=identification)
+            return track.show_tracking_page(request=request,identification=identification)
         except Exception as e:
             print(f"Order page error : {e}")
 
@@ -134,7 +133,7 @@ class Tracking:
         except Exception as e:
             print(e)
     
-    def track(self,request : Request, identification):
+    def show_tracking_page(self,request : Request, identification):
         order = Order().get_order(identification=identification)
         try:
             if not order:
@@ -148,26 +147,26 @@ class Tracking:
                 tracking_id_pattern = r'^EL\d{9}IN'
                 link_pattern = r'https://.*'
                 for key,value in order.items():
-                    
-                    link_matches = re.search(link_pattern,value)
-                    tracking_id_matches = re.match(tracking_id_pattern,value)
-                    
-                    if link_matches:
-                        matched_link = link_matches.group()
-                        value = value.replace(
-                            matched_link, 
-                            f"<a target='_blank' href='{matched_link}'>{matched_link.strip("https://www.")}</a>"
-                        )
+                    if value != None:
+                        link_matches = re.search(link_pattern,value)
+                        tracking_id_matches = re.match(tracking_id_pattern,value)
                         
-                    if tracking_id_matches:
-                        matched_tracking_id = tracking_id_matches.group()
-                        tag = 'span'
-                        value = value.replace(
-                            matched_tracking_id, 
-                            f"<{tag} type='text' class='copy'>{matched_tracking_id}</{tag}>"
-                        )
-                    
-                    order[key] = value
+                        if link_matches:
+                            matched_link = link_matches.group()
+                            value = value.replace(
+                                matched_link, 
+                                f"<a target='_blank' href='{matched_link}'>{matched_link.strip("https://www.")}</a>"
+                            )
+                            
+                        if tracking_id_matches:
+                            matched_tracking_id = tracking_id_matches.group()
+                            tag = 'span'
+                            value = value.replace(
+                                matched_tracking_id, 
+                                f"<{tag} type='text' class='copy'>{matched_tracking_id}</{tag}>"
+                            )
+                        
+                        order[key] = value
                 return templates.TemplateResponse(request=request, name="tracking_result.html", context={"order" : order}) 
         except Exception as e:
             print(e)
@@ -175,7 +174,7 @@ class Tracking:
     def track_order(self,request: Request ,order_id:str=Form()):
         tracked_order = None
         try:
-            tracked_order = self.track(request=request,identification=order_id)
+            tracked_order = self.show_tracking_page(request=request,identification=order_id)
         except Exception as e:
             print(e)
         return tracked_order
@@ -190,10 +189,10 @@ pickup = Pickup()
 router.add_api_route(pickup.base_url + "missing_form", pickup.missing_form,methods=["GET"])
 router.add_api_route(pickup.base_url + "find_missing", pickup.find_missing_orders,methods=["POST"])
 
-track = Tracking()
-router.add_api_route(track.base_url, track.tracking_form,methods=["GET"])
-router.add_api_route(track.base_url , track.track_order, methods=["POST"])
-router.add_api_route(track.base_url + "{identification}", track.track, methods=["GET"])
+tracking = Tracking()
+router.add_api_route(tracking.base_url, tracking.tracking_form,methods=["GET"])
+router.add_api_route(tracking.base_url , tracking.track_order, methods=["POST"])
+router.add_api_route(tracking.base_url + "/{identification}", tracking.show_tracking_page, methods=["GET"])
 
 
 app = FastAPI()


### PR DESCRIPTION
## Summary by Sourcery

Improve tracking page functionality by handling None values and refactoring method names and routes for clarity

Bug Fixes:
- Skip None order values before applying regex matches to prevent NoneType errors

Enhancements:
- Rename Tracking.track method to show_tracking_page and update references accordingly
- Add missing slash to identification endpoint route path
- Rename tracking instance variable for consistency