### PR TITLE
changed myspeedpost tracking link with aftership

### DIFF
--- a/postify/main.py
+++ b/postify/main.py
@@ -141,7 +141,7 @@ class Tracking:
                 aftership = f'https://www.aftership.com/track/india-post/{tracking_id}'
                 myspeedpost = f"https://myspeedpost.com/track?n={tracking_id}"
                 if tracking_id:
-                    return RedirectResponse(url=myspeedpost)
+                    return RedirectResponse(url=aftership)
             else:
                 tracking_id_pattern = r'^EL\d{9}IN'
                 link_pattern = r'https://.*'
@@ -212,4 +212,3 @@ app.add_middleware(
 
 app.mount("/postify/static", StaticFiles(directory="postify/static"), name="postify_static")
 templates = Jinja2Templates(directory="postify/templates")
-


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update tracking redirect to use AfterShip URL in the tracking page handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated order tracking redirects so links with an `https` status now open the correct tracking provider.
  * Improved the routing behavior for affected tracking pages, helping users reach the expected destination more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->